### PR TITLE
Fjernet ymd() i sjekk av relasjoner mellom datoer i kodebok

### DIFF
--- a/R/les_kb_v2.R
+++ b/R/les_kb_v2.R
@@ -1,7 +1,6 @@
 #' @import dplyr
 #' @importFrom tibble tribble tibble
 #' @importFrom stringr str_detect str_c str_to_lower
-#' @importFrom lubridate ymd
 NULL
 
 #' Funksjon for å lese inn kodebok for OQR-register
@@ -816,10 +815,10 @@ eining, desimaler, min, maks, min_rimeleg, maks_rimeleg, min_dato, maks_dato,min
       min_rimeleg < min |
       min_rimeleg > maks_rimeleg |
       maks_rimeleg > maks |
-      ymd(min_dato) > ymd(maks_dato) |
-      ymd(min_rimeleg_dato) < ymd(min_dato) |
-      ymd(min_rimeleg_dato) > ymd(maks_rimeleg_dato) |
-      ymd(maks_rimeleg_dato) > ymd(maks_dato)) %>%
+      min_dato > maks_dato |
+      min_rimeleg_dato < min_dato |
+      min_rimeleg_dato > maks_rimeleg_dato |
+      maks_rimeleg_dato > maks_dato) %>%
     pull(variabel_id)
 
   if (length(feil_relasjon) > 0) {


### PR DESCRIPTION
Har fjernet ymd()-funksjon rundt datovariabler, for å hindre advarsel ved kjøring av tester på github. 