### PR TITLE
Byt frå magrittr-røyr til vanlege R-røyr

### DIFF
--- a/R/dformat-oqr.R
+++ b/R/dformat-oqr.R
@@ -1,6 +1,5 @@
 # Innlesing av kodebøker og datadumpar frå OQR.
 
-#' @importFrom magrittr %>%
 #' @importFrom lubridate as_date
 #' @importFrom stringr str_c str_to_lower str_detect
 #' @importFrom readr col_character col_integer
@@ -45,8 +44,8 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
 
   # Bruk siste tilgjengelege kodebok dersom ein ikkje har valt dato
   if (is.null(dato)) {
-    dato = dir(mappe_dd, pattern = "^[0-9]{4}-[0-1][0-9]-[0-9]{2}$", full.names = FALSE) %>%
-      sort() %>%
+    dato = dir(mappe_dd, pattern = "^[0-9]{4}-[0-1][0-9]-[0-9]{2}$", full.names = FALSE) |>
+      sort() |>
       last()
   }
   dato = as_date(dato) # I tilfelle det var ein tekstreng
@@ -108,7 +107,7 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
   #
   # fixme: Vårt kodebokformat bør nok oppdaterast til
   #        å støtta min- og maks-verdiar for datoar òg.
-  kodebok = kodebok_oqr_format %>%
+  kodebok = kodebok_oqr_format |>
     mutate(
       skjema_id = tabell,
       skjemanamn = skjemanavn,
@@ -201,7 +200,7 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
   # aktiveringsspoersmaal-kolonnen i klokeboken beskriver en variabel åpner opp nye variabler for bruker "Ja" eller ikke "Nei".
   # Er denne "Ja" er den alltid synlig for bruker,
   # og vi kan vite at den da vil være obligatorisk (hvis den også er markert som obligatorisk)
-  kodebok = kodebok %>%
+  kodebok = kodebok |>
     mutate(obligatorisk = ifelse(aktiveringsspoersmaal == "Ja" & obligatorisk == "ja", "ja", "nei"))
 
   # I tillegg til dei definerte variablane har datadumpane seks ekstra
@@ -224,9 +223,9 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
     kb_utvida = bind_rows(kb_ekstra[1:2, ], kb, kb_ekstra[3:8, ])
     kb_utvida
   }
-  kodebok = kodebok %>%
-    tidyr::nest(skjema_kb = c(-skjema_id, -skjemanamn)) %>%
-    mutate(skjema_kb = purrr::map(skjema_kb, legg_til_ekstravar)) %>%
+  kodebok = kodebok |>
+    tidyr::nest(skjema_kb = c(-skjema_id, -skjemanamn)) |>
+    mutate(skjema_kb = purrr::map(skjema_kb, legg_til_ekstravar)) |>
     tidyr::unnest(cols = c(skjema_kb))
 
   # fixme: Sjekk at verdiane til variablane faktiske er *like* på alle tabellane
@@ -241,7 +240,7 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
   # (tre ulike skjemanamn), vil det finnast tre separate oppføringar for
   # «type_kompl», eitt for kvart skjema. Me skal berre ha første. (Men
   # merk at denne kan bestå av fleire *rader*, for kategoriske variablar.)
-  kodebok = kodebok %>%
+  kodebok = kodebok |>
     distinct(skjema_id, variabel_id, verdi, verditekst, .keep_all = TRUE)
 
   # Dei variabel-/kolonnenamna me brukar, i standard/fornuftig rekkjefølgje
@@ -255,7 +254,7 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
 
   # Bruk vidare berre standardkolonnne, og i standard/fornuftig rekkjefølgje
   # (Må stå etter legg_til_ekstravar(), sidan denne endrar rekkjefølgja)
-  kodebok = kodebok %>%
+  kodebok = kodebok |>
     select(!!std_namn)
 
   # Skjemanamna heng ikkje saman med tabellnamna(!). Det ser ut til
@@ -299,7 +298,7 @@ les_kb_oqr = function(mappe_dd, reg_id, dato = NULL, valider_kb = TRUE) { # fixm
   # slik at variablar kjem hulter til bulter. Fiksar derfor dette.
   # Men sorterer *ikkje* alfabetisk, sidan den naturlege rekkjefølgja
   # ofte er meir logisk.
-  kodebok = kodebok %>%
+  kodebok = kodebok |>
     arrange(forcats::fct_inorder(skjema_id))
 
   # Sjekk eventuelt at kodeboka er gyldig
@@ -353,8 +352,8 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
                       valider_kb = is.null(kodebok), valider_dd = TRUE) {
   # Bruk siste tilgjengelege kodebok dersom ein ikkje har valt dato
   if (is.null(dato)) {
-    dato = dir(mappe_dd, pattern = "^[0-9]{4}-[0-1][0-9]-[0-9]{2}$", full.names = FALSE) %>%
-      sort() %>%
+    dato = dir(mappe_dd, pattern = "^[0-9]{4}-[0-1][0-9]-[0-9]{2}$", full.names = FALSE) |>
+      sort() |>
       last()
   }
   dato = as_date(dato) # I tilfelle det var ein tekstreng
@@ -364,7 +363,7 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
     kodebok = les_kb_oqr(mappe_dd, reg_id, dato, valider_kb = valider_kb)
   }
   # Hent ut variabelinfo frå kodeboka for det gjeldande skjemaet
-  kb_akt = kodebok %>%
+  kb_akt = kodebok |>
     filter(skjema_id == !!skjema_id)
 
   # Kodeboka må ha informasjon om variablane i
@@ -419,7 +418,7 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
 
   # Hent ut første linje frå kodeboka, dvs. den linja som
   # inneheld aktuell informasjon
-  kb_info = kodebok %>%
+  kb_info = kodebok |>
     distinct(variabel_id, .keep_all = TRUE)
 
   # Forkortingsbokstavane som read_csv() brukar (fixme: utvide med fleire)
@@ -433,8 +432,8 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
     "dato", "D",
     "kl", "t"
   )
-  spek_innlesing = tibble(variabel_id = varnamn_kb) %>%
-    left_join(kb_info, by = "variabel_id", relationship = "one-to-one") %>%
+  spek_innlesing = tibble(variabel_id = varnamn_kb) |>
+    left_join(kb_info, by = "variabel_id", relationship = "one-to-one") |>
     left_join(spek_csv_oqr, by = "variabeltype", relationship = "many-to-one")
 
   # Har kodeboka variablar av ein type me ikkje har lagt inn støtte for?
@@ -469,7 +468,7 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
   # Filtrer vekk skjema som ikkje har rett statusvariabel
   # (som standard vert berre ferdigstilte skjema tekne med)
   if (!is.null(status)) {
-    d = d %>%
+    d = d |>
       filter(status %in% !!status)
   }
 
@@ -499,14 +498,14 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
   # stopifnot(all(!er_tal(c("a", "2B", "F42.7", "-x", "1e-7", "3.", ".7")))) # Ev. godta "3." og .7"?
 
   # Finn dei kategoriske variablane som har berre numeriske verdiar ...
-  vars_num = kb_akt %>%
-    filter(variabeltype == "kategorisk") %>%
-    group_by(variabel_id) %>%
-    summarise(er_talkat = all(er_tal(verdi))) %>%
-    filter(er_talkat) %>%
+  vars_num = kb_akt |>
+    filter(variabeltype == "kategorisk") |>
+    group_by(variabel_id) |>
+    summarise(er_talkat = all(er_tal(verdi))) |>
+    filter(er_talkat) |>
     pull(variabel_id)
   # ... og gjer tilhøyrande innlesne variablar (om det er nokon) om til talvariablar
-  d = d %>%
+  d = d |>
     mutate_at(vars_num, as.numeric)
 
   # Gjer eventuelle boolske variablar om til ekte boolske variablar
@@ -520,7 +519,7 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
     }
   }
   vars_boolsk = spek_innlesing$variabel_id[spek_innlesing$variabeltype == "boolsk"]
-  d = d %>%
+  d = d |>
     mutate_at(vars_boolsk, oqr_boolsk_til_boolsk)
 
   # Gjer eventuelle tidsvariablar om til ekte tidsvariablar
@@ -528,7 +527,7 @@ les_dd_oqr = function(mappe_dd, reg_id, skjema_id, status = 1, dato = NULL, kode
   #        Fjern når denne feilen er fiksa (rett då òg fixme-en
   #        lenger oppe som også handlar om dette)
   vars_datokl = spek_innlesing$variabel_id[spek_innlesing$variabeltype == "dato_kl"]
-  d = d %>%
+  d = d |>
     mutate_at(vars_datokl, readr::parse_datetime,
       format = "%Y-%m-%d %H:%M:%OS",
       locale = oqr_lokale

--- a/R/rapporttekst-funksjoner.R
+++ b/R/rapporttekst-funksjoner.R
@@ -1,7 +1,6 @@
 # Dette skriptet inneholder en rekke funksjoner som er potensielt nyttige
 # (og noen, uunnværlige) i registersammenheng og i andre sammenheng.
 
-#' @importFrom magrittr %>%
 #' @importFrom stringr str_flatten
 NULL
 
@@ -185,8 +184,8 @@ akse_tall_format = function(antall_desimaler = 2, decimal.mark = ",", big.mark =
 #' # Til bruk i setning i latex
 #' paste0("Andel menn er ", prosent(andel_menn), ".")
 prosent = function(x, desimalar = 0) {
-  prosent_tekst = x %>%
-    purrr::map_chr(~ num(100 * .x, desimalar) %>%
+  prosent_tekst = x |>
+    purrr::map_chr(~ num(100 * .x, desimalar) |>
       stringr::str_c("\\prosent"))
   ifelse(is.na(x), "\\textendash{}", prosent_tekst)
 }

--- a/tests/testthat/test-kodebok-fyll.R
+++ b/tests/testthat/test-kodebok-fyll.R
@@ -24,14 +24,14 @@ kb = tribble(
 )
 
 # Nivåa til dei ulike faktorane (i rett rekkjefølgje)
-niv_kjonn = kb %>%
-  filter(variabel_id == "kjonn") %>%
+niv_kjonn = kb |>
+  filter(variabel_id == "kjonn") |>
   pull(verditekst)
-niv_med = kb %>%
-  filter(variabel_id == "med") %>%
+niv_med = kb |>
+  filter(variabel_id == "med") |>
   pull(verditekst)
-niv_gensp = kb %>%
-  filter(variabel_id == "gensp") %>%
+niv_gensp = kb |>
+  filter(variabel_id == "gensp") |>
   pull(verditekst)
 
 # Ymse testar basert på kravspek ------------------------------------------
@@ -47,12 +47,12 @@ test_that("Enkel bruk utan nokon argument fungerer (side 4)", {
     102, 1, "mann", 37, 4, "Globoid", 2,
     103, 1, "mann", 17, 1, "Antibac", 3
   )
-  d_fylt = d_fylt %>%
+  d_fylt = d_fylt |>
     mutate(
       kjonn_tekst = factor(kjonn_tekst, levels = niv_kjonn),
       med_tekst = factor(med_tekst, levels = niv_med)
     )
-  expect_identical(d %>% kb_fyll(kb), d_fylt)
+  expect_identical(kb_fyll(d, kb), d_fylt)
 })
 
 # Side 5
@@ -63,9 +63,9 @@ test_that("Val av variabel å fylla ut fungerer (side 5)", {
     102, 1, "mann", 37, 4, 2,
     103, 1, "mann", 17, 1, 3
   )
-  d_fylt = d_fylt %>%
+  d_fylt = d_fylt |>
     mutate(kjonn_tekst = factor(kjonn_tekst, levels = niv_kjonn))
-  expect_identical(d %>% kb_fyll(kb, kjonn), d_fylt)
+  expect_identical(kb_fyll(d, kb, kjonn), d_fylt)
 })
 
 # Side 6
@@ -76,13 +76,13 @@ test_that("Val av variabel som har anna namn i kodeboka fungerer (side 6)", {
     102, 1, "mann", 37, 4, 2, "både og",
     103, 1, "mann", 17, 1, 3, "fornøgd"
   )
-  d_fylt = d_fylt %>%
+  d_fylt = d_fylt |>
     mutate(
       kjonn_tekst = factor(kjonn_tekst, levels = niv_kjonn),
       prem_tekst = factor(prem_tekst, levels = niv_gensp)
     )
-  expect_identical(d %>% kb_fyll(kb, kjonn, prem = "gensp"), d_fylt)
-  expect_identical(d %>% kb_fyll(kb, kjonn, prem = gensp), d_fylt)
+  expect_identical(kb_fyll(d, kb, kjonn, prem = "gensp"), d_fylt)
+  expect_identical(kb_fyll(d, kb, kjonn, prem = gensp), d_fylt)
 })
 
 test_that("Variablar med faktornivå i spesiell rekkjefølgje fungerer", {
@@ -97,16 +97,15 @@ test_that("Variablar med faktornivå i spesiell rekkjefølgje fungerer", {
     "hei", 1, "bar",
     "hei", 12, "baz"
   )
-  kb3 = kb2 %>%
-    mutate(verdi = as.character(verdi))
+  kb3 = mutate(kb2, verdi = as.character(verdi))
   # Merk at kb2$verdi er ulik sort(kb2$verdi) og at begge er ulik sort(kb3$verdi)
 
   # Dette skal bli resultatet, uavhengig av kva kodebokvariant ein brukar
-  d_fylt = d2 %>%
-    mutate(hei_tekst = factor(hei, levels = kb2$verdi, labels = kb2$verditekst)) %>%
+  d_fylt = d2 |>
+    mutate(hei_tekst = factor(hei, levels = kb2$verdi, labels = kb2$verditekst)) |>
     dplyr::select(pasid, hei, hei_tekst, alder)
-  expect_identical(d2 %>% kb_fyll(kb2), d_fylt)
-  expect_identical(d2 %>% kb_fyll(kb3), d_fylt)
+  expect_identical(kb_fyll(d2, kb2), d_fylt)
+  expect_identical(kb_fyll(d2, kb3), d_fylt)
 })
 
 
@@ -115,33 +114,31 @@ test_that("Variablar med faktornivå i spesiell rekkjefølgje fungerer", {
 context("Feilmeldingar og åtvaringar")
 
 test_that("Feilmelding ved bruk av variabel med implisitt namn som ikkje finst i kodeboka (side 7)", {
-  expect_error(d %>% kb_fyll(kb, kjonn, test), "Variabel finst ikkje i kodeboka: 'test'")
-  expect_error(d %>% kb_fyll(kb, kjonn, test, hei), "Variablar finst ikkje i kodeboka: 'test', 'hei'")
-  expect_error(d %>% kb_fyll(kb, test, hei), "Variablar finst ikkje i kodeboka: 'test', 'hei'")
+  expect_error(kb_fyll(d, kb, kjonn, test), "Variabel finst ikkje i kodeboka: 'test'")
+  expect_error(kb_fyll(d, kb, kjonn, test, hei), "Variablar finst ikkje i kodeboka: 'test', 'hei'")
+  expect_error(kb_fyll(d, kb, test, hei), "Variablar finst ikkje i kodeboka: 'test', 'hei'")
 })
 
 test_that("Feilmelding ved bruk av variabel med eksplisitt namn som ikkje finst i kodeboka (side 8)", {
-  expect_error(d %>% kb_fyll(kb, kjonn, prem = "gen"), "Variabel finst ikkje i kodeboka: 'gen'")
+  expect_error(kb_fyll(d, kb, kjonn, prem = "gen"), "Variabel finst ikkje i kodeboka: 'gen'")
 })
 
 test_that("Feilmelding ved bruk av variabel med eksplisitt namn som ikkje finst i datasettet (men i kodeboka)", {
-  d2 = d %>%
-    dplyr::select(-med)
-  d3 = d %>%
-    dplyr::select(-med, -kjonn)
-  expect_error(d2 %>% kb_fyll(kb, med), "Variabel finst ikkje i datasettet: 'med'")
-  expect_error(d3 %>% kb_fyll(kb, med, kjonn), "Variablar finst ikkje i datasettet: 'med', 'kjonn'")
+  d2 = dplyr::select(d, -med)
+  d3 = dplyr::select(d, -med, -kjonn)
+  expect_error(kb_fyll(d2, kb, med), "Variabel finst ikkje i datasettet: 'med'")
+  expect_error(kb_fyll(d3, kb, med, kjonn), "Variablar finst ikkje i datasettet: 'med', 'kjonn'")
 })
 
 test_that("Åtvaring (men NA-verdi) viss datasettet inneheld verdiar som aktuell variabel ikkje har i kodeboka (side 9)", {
-  expect_warning(d %>% kb_fyll(kb[-6, ]), "Variabelen 'med' har ugyldig verdi (vart gjort om til NA): '4'", fixed = TRUE)
-  expect_warning(d %>% kb_fyll(kb[-c(3, 6), ]), "Variabelen 'med' har ugyldige verdiar (vart gjort om til NA): '1', '4'", fixed = "TRUE") # Sorter dei ugyldige verdiane
-  expect_warning(d %>% kb_fyll(kb[-1, ]), "Variabelen 'kjonn' har ugyldig verdi (vart gjort om til NA): '1'", fixed = "TRUE") # Eintal og berre vist éin gong, sjølv om feilen er i fleire rader
+  expect_warning(kb_fyll(d, kb[-6, ]), "Variabelen 'med' har ugyldig verdi (vart gjort om til NA): '4'", fixed = TRUE)
+  expect_warning(kb_fyll(d, kb[-c(3, 6), ]), "Variabelen 'med' har ugyldige verdiar (vart gjort om til NA): '1', '4'", fixed = "TRUE") # Sorter dei ugyldige verdiane
+  expect_warning(kb_fyll(d, kb[-1, ]), "Variabelen 'kjonn' har ugyldig verdi (vart gjort om til NA): '1'", fixed = "TRUE") # Eintal og berre vist éin gong, sjølv om feilen er i fleire rader
 
   # Sjekk at ein får NA-verdiar der det manglar i kodeboka
   # (men ikkje NA-verdiar der det ikkje manglar, sjølv om det
   # er snakk om same variabel)
-  d_fylt = suppressWarnings(d %>% kb_fyll(kb[-6, ]))
+  d_fylt = suppressWarnings(kb_fyll(d, kb[-6, ]))
   expect_true(is.na(d_fylt$med_tekst[2]))
   expect_equal(as.character(d_fylt$med_tekst[1]), "Ibux")
   expect_equal(as.character(d_fylt$med_tekst[3]), "Antibac")
@@ -151,27 +148,27 @@ test_that("Ikkje åtvaring eller feilmelding viss datasettet inneheld NA-verdiar
   d2 = d
   d2$kjonn[3] = NA
 
-  expect_warning(d2 %>% kb_fyll(kb), NA)
-  expect_error(d2 %>% kb_fyll(kb), NA)
+  expect_warning(kb_fyll(d2, kb), NA)
+  expect_error(kb_fyll(d2, kb), NA)
 })
 
 test_that("Åtvaring (men resultat) viss kodeboka ikkje inneheld *nokon* variablar som finst i datasettet", {
   kb2 = kb
   kb2$variabel_id = paste0("x_", kb2$variabel_id)
 
-  d2 = suppressWarnings(d %>% kb_fyll(kb2))
+  d2 = suppressWarnings(kb_fyll(d, kb2))
   expect_identical(d2, d)
-  expect_warning(d %>% kb_fyll(kb2), "Kodeboka inneheld ingen variablar som finst i datasettet.")
+  expect_warning(kb_fyll(d, kb2), "Kodeboka inneheld ingen variablar som finst i datasettet.")
 })
 
 test_that("Feilmelding viss kodeboka ikkje inneheld dei nødvendige kolonnane (side 10)", {
   feilmelding = "Ugyldig kodebok. Obligatoriske kolonnar er 'variabel_id', 'verdi' og 'verditekst'."
-  expect_error(d %>% kb_fyll(iris), feilmelding)
-  expect_error(d %>% kb_fyll(kb[-1]), feilmelding)
-  expect_error(d %>% kb_fyll(kb[-2]), feilmelding)
-  expect_error(d %>% kb_fyll(kb[-3]), feilmelding)
-  expect_error(d %>% kb_fyll(kb[3:1]), NA) # Godta forskjellig rekkjefølgje
-  expect_error(d %>% kb_fyll(cbind(x = 1:nrow(kb), kb[3:1], y = 1:nrow(kb))), NA) # Godta ekstrakolonnar
+  expect_error(kb_fyll(d, iris), feilmelding)
+  expect_error(kb_fyll(d, kb[-1]), feilmelding)
+  expect_error(kb_fyll(d, kb[-2]), feilmelding)
+  expect_error(kb_fyll(d, kb[-3]), feilmelding)
+  expect_error(kb_fyll(d, kb[3:1]), NA) # Godta forskjellig rekkjefølgje
+  expect_error(kb_fyll(d, cbind(x = 1:nrow(kb), kb[3:1], y = 1:nrow(kb))), NA) # Godta ekstrakolonnar
 })
 
 test_that("NA-verdiar i kodeboka vert oppdaga", {
@@ -184,9 +181,9 @@ test_that("NA-verdiar i kodeboka vert oppdaga", {
   kb4 = kb
   kb4$verditekst[2] = NA
 
-  expect_error(d %>% kb_fyll(kb2), "Ugyldig kodebok. Kolonnen 'variabel_id' har NA-verdi(ar).", fixed = TRUE)
-  expect_error(d %>% kb_fyll(kb3), "Ugyldig kodebok. Kolonnen 'verdi' har NA-verdi(ar).", fixed = TRUE)
-  expect_error(d %>% kb_fyll(kb4), "Ugyldig kodebok. Kolonnen 'verditekst' har NA-verdi(ar).", fixed = TRUE)
+  expect_error(kb_fyll(d, kb2), "Ugyldig kodebok. Kolonnen 'variabel_id' har NA-verdi(ar).", fixed = TRUE)
+  expect_error(kb_fyll(d, kb3), "Ugyldig kodebok. Kolonnen 'verdi' har NA-verdi(ar).", fixed = TRUE)
+  expect_error(kb_fyll(d, kb4), "Ugyldig kodebok. Kolonnen 'verditekst' har NA-verdi(ar).", fixed = TRUE)
 })
 
 test_that("Dupliserte verdiar i kodeboka vert oppdaga", {
@@ -203,10 +200,10 @@ test_that("Dupliserte verdiar i kodeboka vert oppdaga", {
   kb5 = kb
   kb5$foo = 3 # *Ikkje* duplisert verdi (er frå kolonne som ikkje er 'verdi' eller 'verditekst')
 
-  expect_error(d2 %>% kb_fyll(kb2), "Ugyldig kodebok. Variabelen 'med' har dupliserte verdiar i kolonnen 'verdi'.")
-  expect_error(d %>% kb_fyll(kb3), "Ugyldig kodebok. Variabelen 'med' har dupliserte verdiar i kolonnen 'verditekst'.")
-  expect_error(d %>% kb_fyll(kb4), NA)
-  expect_error(d %>% kb_fyll(kb5), NA)
+  expect_error(kb_fyll(d2, kb2), "Ugyldig kodebok. Variabelen 'med' har dupliserte verdiar i kolonnen 'verdi'.")
+  expect_error(kb_fyll(d, kb3), "Ugyldig kodebok. Variabelen 'med' har dupliserte verdiar i kolonnen 'verditekst'.")
+  expect_error(kb_fyll(d, kb4), NA)
+  expect_error(kb_fyll(d, kb5), NA)
 })
 
 test_that("NA-verdiar i 'verdi' vert godtekne så lenge dei berre er blant ikkje-kategoriske variablar", {
@@ -221,8 +218,8 @@ test_that("NA-verdiar i 'verdi' vert godtekne så lenge dei berre er blant ikkje
 
   # Skal ikkje gje åtvaring eller feilmelding, sidan
   # NA-verdiane ikkje er blant dei kategoriske variablane
-  expect_error(d %>% kb_fyll(kb2), NA)
-  expect_warning(d %>% kb_fyll(kb2), NA)
+  expect_error(kb_fyll(d, kb2), NA)
+  expect_warning(kb_fyll(d, kb2), NA)
 })
 
 test_that("Kodebokkolonnar lagra som faktorar vert oppdaga (og straffa!)", {
@@ -232,10 +229,10 @@ test_that("Kodebokkolonnar lagra som faktorar vert oppdaga (og straffa!)", {
   kb4$verditekst = factor(kb4$verditekst)
   kb5$foo = factor("test") # Ekstrakolonne, som det er uproblematisk at er faktor
 
-  expect_error(d %>% kb_fyll(kb2), "Ugyldig kodebok. Kolonnen 'variabel_id' er faktor.")
-  expect_error(d %>% kb_fyll(kb3), "Ugyldig kodebok. Kolonnen 'verdi' er faktor.")
-  expect_error(d %>% kb_fyll(kb4), "Ugyldig kodebok. Kolonnen 'verditekst' er faktor.")
-  expect_error(d %>% kb_fyll(kb5), NA) # Skal ikkje gje åtvaring
+  expect_error(kb_fyll(d, kb2), "Ugyldig kodebok. Kolonnen 'variabel_id' er faktor.")
+  expect_error(kb_fyll(d, kb3), "Ugyldig kodebok. Kolonnen 'verdi' er faktor.")
+  expect_error(kb_fyll(d, kb4), "Ugyldig kodebok. Kolonnen 'verditekst' er faktor.")
+  expect_error(kb_fyll(d, kb5), NA) # Skal ikkje gje åtvaring
 })
 
 
@@ -250,9 +247,8 @@ test_that("Val av suffiks fungerer (side 11)", {
     102, 1, 37, 4, "Globoid", 2,
     103, 1, 17, 1, "Antibac", 3
   )
-  d_fylt = d_fylt %>%
-    mutate(med_hei = factor(med_hei, levels = niv_med))
-  expect_identical(d %>% kb_fyll(kb, med, .suffiks = "_hei"), d_fylt)
+  d_fylt = mutate(d_fylt, med_hei = factor(med_hei, levels = niv_med))
+  expect_identical(kb_fyll(d, kb, med, .suffiks = "_hei"), d_fylt)
 })
 
 test_that("Tomt suffiks fungerer (og gjev åtvaring) (side 12)", {
@@ -262,14 +258,14 @@ test_that("Tomt suffiks fungerer (og gjev åtvaring) (side 12)", {
     102, "mann", 37, "Globoid", 2,
     103, "mann", 17, "Antibac", 3
   )
-  d_fylt = d_fylt %>%
+  d_fylt = d_fylt |>
     mutate(
       kjonn = factor(kjonn, levels = niv_kjonn),
       med = factor(med, levels = niv_med)
     )
-  expect_identical(suppressWarnings(d %>% kb_fyll(kb, .suffiks = "")), d_fylt)
-  expect_warning(d %>% kb_fyll(kb, .suffiks = ""), "Overskriv variabel: 'kjonn'")
-  expect_warning(d %>% kb_fyll(kb, .suffiks = ""), "Overskriv variabel: 'med'")
+  expect_identical(suppressWarnings(kb_fyll(d, kb, .suffiks = "")), d_fylt)
+  expect_warning(kb_fyll(d, kb, .suffiks = ""), "Overskriv variabel: 'kjonn'")
+  expect_warning(kb_fyll(d, kb, .suffiks = ""), "Overskriv variabel: 'med'")
 })
 
 test_that("Overskriving av variablar ved *ikkje-tomt* suffiks gjev også åtvaring (men fungerer)", {
@@ -285,10 +281,9 @@ test_that("Overskriving av variablar ved *ikkje-tomt* suffiks gjev også åtvari
     102, 1, "mann",
     103, 1, "mann"
   )
-  d2_fylt = d2_fylt %>%
-    mutate(kjonntest = factor(kjonntest, levels = niv_kjonn))
-  expect_warning(d2 %>% kb_fyll(kb, .suffiks = "test"), "Overskriv variabel: 'kjonntest'")
-  expect_identical(suppressWarnings(d2 %>% kb_fyll(kb, .suffiks = "test")), d2_fylt)
+  d2_fylt = mutate(d2_fylt, kjonntest = factor(kjonntest, levels = niv_kjonn))
+  expect_warning(kb_fyll(d2, kb, .suffiks = "test"), "Overskriv variabel: 'kjonntest'")
+  expect_identical(suppressWarnings(kb_fyll(d2, kb, .suffiks = "test")), d2_fylt)
 })
 
 
@@ -297,20 +292,18 @@ test_that("Overskriving av variablar ved *ikkje-tomt* suffiks gjev også åtvari
 context("Grensetilfelle og småplukk")
 
 test_that("Variabelkolonnar som står heilt først eller sist i datasettet fungerer òg", {
-  d2 = d %>%
-    dplyr::select(kjonn, med)
+  d2 = dplyr::select(d, kjonn, med)
   d_fylt = tribble(
     ~kjonn, ~med,
     "kvinne", "Ibux",
     "mann", "Globoid",
     "mann", "Antibac"
   )
-  d_fylt = d_fylt %>%
-    mutate(
-      kjonn = factor(kjonn, levels = niv_kjonn),
-      med = factor(med, levels = niv_med)
-    )
-  expect_identical(suppressWarnings(d2 %>% kb_fyll(kb, .suffiks = "")), d_fylt)
+  d_fylt = mutate(d_fylt,
+    kjonn = factor(kjonn, levels = niv_kjonn),
+    med = factor(med, levels = niv_med)
+  )
+  expect_identical(suppressWarnings(kb_fyll(d2, kb, .suffiks = "")), d_fylt)
 })
 
 test_that("Lause variablar som heiter det same som variablar i datasettet fører ikkje til problem", {
@@ -320,20 +313,38 @@ test_that("Lause variablar som heiter det same som variablar i datasettet fører
     102, 1, "mann", 37, 4, 2,
     103, 1, "mann", 17, 1, 3
   )
-  d_fylt = d_fylt %>%
-    mutate(kjonn_tekst = factor(kjonn_tekst, levels = niv_kjonn))
-  d2_fylt = d_fylt %>%
-    mutate(prem_tekst = factor(c("både og", "både og", "fornøgd"), levels = niv_gensp))
+  d_fylt = mutate(d_fylt, kjonn_tekst = factor(kjonn_tekst, levels = niv_kjonn))
+  d2_fylt = mutate(d_fylt,
+    prem_tekst = factor(c("både og", "både og", "fornøgd"), levels = niv_gensp)
+  )
   kjonn = "med"
   gensp = "med"
-  expect_identical(d %>% kb_fyll(kb, kjonn), d_fylt)
-  expect_identical(d %>% kb_fyll(kb, prem = "gensp", kjonn), d2_fylt)
-  expect_identical(d %>% kb_fyll(kb, prem = "gensp", kjonn), d %>% kb_fyll(kb, prem = gensp, kjonn))
+  expect_identical(kb_fyll(d, kb, kjonn), d_fylt)
+  expect_identical(kb_fyll(d, kb, prem = "gensp", kjonn), d2_fylt)
+  expect_identical(kb_fyll(d, kb, prem = "gensp", kjonn), kb_fyll(d, kb, prem = gensp, kjonn))
 })
 
 test_that("Funksjonen er idempotent", {
   # Kan ikkje testa alt, men nokre få eksempel sikrar det viktigaste
-  expect_identical(d %>% kb_fyll(kb), suppressWarnings(d %>% kb_fyll(kb) %>% kb_fyll(kb)))
-  expect_identical(d %>% kb_fyll(kb, med), suppressWarnings(d %>% kb_fyll(kb, med) %>% kb_fyll(kb, med)))
-  expect_identical(d %>% kb_fyll(kb, med, prem = "gensp"), suppressWarnings(d %>% kb_fyll(kb, med, prem = "gensp") %>% kb_fyll(kb, med, prem = "gensp")))
+  expect_identical(
+    kb_fyll(d, kb),
+    suppressWarnings(
+      kb_fyll(d, kb) |>
+        kb_fyll(kb)
+    )
+  )
+  expect_identical(
+    kb_fyll(d, kb, med),
+    suppressWarnings(
+      kb_fyll(d, kb, med) |>
+        kb_fyll(kb, med)
+    )
+  )
+  expect_identical(
+    kb_fyll(d, kb, med, prem = "gensp"),
+    suppressWarnings(
+      kb_fyll(d, kb, med, prem = "gensp") |>
+        kb_fyll(kb, med, prem = "gensp")
+    )
+  )
 })


### PR DESCRIPTION
Nokre plassar var det brukt røyr unødvendig. Der har eg fjerna røyra, jf. avsnittet «Korte røyr» i kodestildokumentet vår.