### PR TITLE
Krev R-versjon som støttar det nye røyret

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,3 +66,5 @@ Suggests:
     callr,
     pkgload
 VignetteBuilder: knitr
+Depends: 
+    R (>= 4.1)


### PR DESCRIPTION
Det nye røyret som er direkte støtta i R
(dvs. |> i staden for %>% frå magrittr-pakken)
krev R versjon 4.1.0 eller høgare.