### PR TITLE
Fjern tomme @details-avsnitt i figur-funksjonar

### DIFF
--- a/R/figur-funksjoner.R
+++ b/R/figur-funksjoner.R
@@ -198,8 +198,6 @@ lag_fig_shewhart = function(d, y, x, nevner = NULL, figtype, tittel = NULL,
 #' Ekstra argument som vert gjeve vidare til [lag_fig_soyle_grunnplott()]
 #' (og så vidare igjen til [ggplot2::geom_col()]).
 #'
-#' @details
-#'
 #' @return Eit søylediagram som ggplot-objekt.
 #'
 #' @export
@@ -233,8 +231,6 @@ lag_fig_soyle = function(d, x, y, flip = TRUE, ...) {
 #' @param ...
 #' Ekstra argument som vert gjeve vidare til [lag_fig_soyle_grunnplott()]
 #' (og så vidare igjen til [ggplot2::geom_col()]).
-#'
-#' @details
 #'
 #' @return Eit søylediagram som ggplot-objekt.
 #'
@@ -270,8 +266,6 @@ lag_fig_soyle_prosent = function(d, x, y, flip = TRUE, ...) {
 #' Logisk variabel som seier om plottet skal flippast. Standard verdi = `TRUE`.
 #' @param ...
 #' Ekstra argument som vert gjeve vidare til [ggplot2::geom_col()].
-#'
-#' @details
 #'
 #' @return Eit søylediagram som ggplot-objekt.
 #'


### PR DESCRIPTION
Desse har i lang tid gjeve åtvaringar sidan dei er tomme. Funksjonane er under utvikling/vurdering og skal koma opp på høgare nivå (og få detaljar) etter kvart.