### PR TITLE
Bytt frå argumentet `alfa` til `konf_niva` i aktuelle funksjonar og testar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Imports:
     boot,
     tidyselect,
     methods,
-    checkmate (>= 1.7.0)
+    checkmate (>= 1.7.0),
+    lifecycle
 RdMacros: Rdpack
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/R/aggreger_ki_prop.R
+++ b/R/aggreger_ki_prop.R
@@ -14,6 +14,10 @@
 #' @param konf_niva
 #' Konfidensnivå.
 #' Standardverdi er 0.95, som tilsvarer et 95 %-konfidensintervall.
+#' @param alfa
+#' `r lifecycle::badge("deprecated")`
+#' Utdatert og erstatta av `konf_niva` (tilsvarande `1 - alfa`).
+#' Vert fjerna i neste versjon av pakken.
 #'
 #' @details
 #' Inndatasettet må inneholde minst de to logiske variablene

--- a/R/aggreger_ki_rate.R
+++ b/R/aggreger_ki_rate.R
@@ -15,6 +15,10 @@
 #' Standardverdi er 0.95, som tilsvarer et 95 %-konfidensintervall.
 #' @param multiplikator Tallverdi som skal multipliseres med raten
 #' (for å vise raten per `multiplikator` enheter i utdatene).
+#' @param alfa
+#' `r lifecycle::badge("deprecated")`
+#' Utdatert og erstatta av `konf_niva` (tilsvarande `1 - alfa`).
+#' Vert fjerna i neste versjon av pakken.
 #'
 #' @details
 #' Inndatasettet må inneholde minst de tre variablene `ki_antall`,

--- a/R/aggreger_ki_snitt.R
+++ b/R/aggreger_ki_snitt.R
@@ -14,6 +14,10 @@
 #' @param konf_niva
 #' Konfidensnivå.
 #' Standardverdi er 0.95, som tilsvarer et 95 %-konfidensintervall.
+#' @param alfa
+#' `r lifecycle::badge("deprecated")`
+#' Utdatert og erstatta av `konf_niva` (tilsvarande `1 - alfa`).
+#' Vert fjerna i neste versjon av pakken.
 #'
 #' @details
 #' Inndatasettet må inneholde minst de to variablene

--- a/R/ymse-funksjoner.R
+++ b/R/ymse-funksjoner.R
@@ -120,6 +120,10 @@ tab = function(...) {
 #' @param konf_niva
 #' Konfidensnivå.
 #' Standardverdi er 0.95, som tilsvarer et 95 %-konfidensintervall.
+#' @param alfa
+#' `r lifecycle::badge("deprecated")`
+#' Utdatert og erstatta av `konf_niva` (tilsvarande `1 - alfa`).
+#' Vert fjerna i neste versjon av pakken.
 #'
 #' @return
 #' Returnerer en tibble med nedre og øvre grense for et

--- a/R/ymse-funksjoner.R
+++ b/R/ymse-funksjoner.R
@@ -117,8 +117,9 @@ tab = function(...) {
 #'
 #' @param x Antall suksesser i forsøket.
 #' @param n Antall uavhengige forsøk.
-#' @param alfa Én minus nivået til konfidensintervallet.
-#'   Standardverdi er 0.05, som tilsvarer et 95 %-konfidensintervall.
+#' @param konf_niva
+#' Konfidensnivå.
+#' Standardverdi er 0.95, som tilsvarer et 95 %-konfidensintervall.
 #'
 #' @return
 #' Returnerer en tibble med nedre og øvre grense for et
@@ -130,8 +131,22 @@ tab = function(...) {
 #' n_forsok = 1000
 #' n_suksess = sample.int(n_forsok, 1)
 #' regn_konfint_bin(n_suksess, n_forsok)
-regn_konfint_bin = function(x, n, alfa = 0.05) {
-  ki = binom::binom.wilson(x, n, 1 - alfa)
+regn_konfint_bin = function(x, n, konf_niva = 0.95, alfa = lifecycle::deprecated()) {
+  # Åtvar viss nokon brukar det utdaterte «alfa»-argumentet
+  if (lifecycle::is_present(alfa)) {
+    lifecycle::deprecate_warn(
+      when = "0.6.0",
+      what = "regn_konfint_bin(alfa)",
+      with = "regn_konfint_bin(konf_niva)",
+      details = paste0(
+        "`konf_niva` corresponds to 1 - `alfa`. ",
+        "`alfa` will be completely dropped in the next version."
+      )
+    )
+    konf_niva = 1 - alfa
+  }
+
+  ki = binom::binom.wilson(x, n, konf_niva)
   tibble(
     lower = pmax(0, ki$lower), # Fiks for at grensene av og til kan gå *bitte litt* utanfor [0,1]
     upper = pmin(1, ki$upper)

--- a/tests/testthat/test-aggreger_ki_prop.R
+++ b/tests/testthat/test-aggreger_ki_prop.R
@@ -392,3 +392,13 @@ test_that(paste0(
   expect_identical(aggreger_ki_prop(d_test_tibble), d_res_tibble)
   expect_identical(aggreger_ki_prop(d_test_df), d_res_df)
 })
+
+test_that("Bruk av alfa gjev same svar som tilsvarande konf_niva", {
+  d = tibble(
+    ki_krit_teller = c(TRUE, FALSE, FALSE, FALSE),
+    ki_krit_nevner = c(rep(TRUE, 4))
+  )
+  expect_identical(suppressWarnings(aggreger_ki_prop(d, alfa = 0.2)),
+    expected = aggreger_ki_prop(d, konf_niva = 0.8)
+  )
+})

--- a/tests/testthat/test-aggreger_ki_prop.R
+++ b/tests/testthat/test-aggreger_ki_prop.R
@@ -85,16 +85,24 @@ test_that(paste0(
   expect_error(aggreger_ki_prop(d_nevner_med_feil), feilmelding_nevner)
 })
 
-test_that("Feilmelding hvis alfa ikke er et tall mellom 0 og 1", {
+test_that("Feilmelding hvis konf_niva ikke er et tall mellom 0 og 1", {
   d_teller_ok = tibble(
     ki_krit_teller = c(FALSE, TRUE, FALSE),
     ki_krit_nevner = c(TRUE, TRUE, FALSE)
   )
-  feilmelding_alfa = "«alfa» må være et tall mellom 0 og 1"
-  expect_error(aggreger_ki_prop(d_teller_ok, alfa = 1.2), feilmelding_alfa)
-  expect_error(aggreger_ki_prop(d_teller_ok, alfa = 0), feilmelding_alfa)
-  expect_error(aggreger_ki_prop(d_teller_ok, alfa = 1), feilmelding_alfa)
-  expect_error(aggreger_ki_prop(d_teller_ok, alfa = "0.05"), feilmelding_alfa)
+  feilmelding_konf_niva = "«konf_niva» må være et tall mellom 0 og 1"
+  expect_error(aggreger_ki_prop(d_teller_ok, konf_niva = 1.2),
+    regexp = feilmelding_konf_niva
+  )
+  expect_error(aggreger_ki_prop(d_teller_ok, konf_niva = 0),
+    regexp = feilmelding_konf_niva
+  )
+  expect_error(aggreger_ki_prop(d_teller_ok, konf_niva = 1),
+    regexp = feilmelding_konf_niva
+  )
+  expect_error(aggreger_ki_prop(d_teller_ok, konf_niva = "0.05"),
+    regexp = feilmelding_konf_niva
+  )
 })
 
 test_that(paste0(
@@ -342,18 +350,18 @@ test_that("Funksjonen støtter angivelse av konfidensinvå", {
     ki_krit_teller = c(TRUE, FALSE, FALSE, FALSE),
     ki_krit_nevner = c(TRUE, TRUE, TRUE, FALSE)
   )
-  d_svar_05 = tibble(
+  d_svar_95 = tibble(
     est = 0.3333333333333333, ki_teller = 1L, ki_nevner = 3L,
     konfint_nedre = 0.06149194472039624, konfint_ovre = 0.7923403991979524
   )
-  d_svar_10 = tibble(
+  d_svar_90 = tibble(
     est = 0.3333333333333333, ki_teller = 1L, ki_nevner = 3L,
     konfint_nedre = 0.07826572633372843, konfint_ovre = 0.7464661317187757
   )
 
-  expect_identical(aggreger_ki_prop(d_test), d_svar_05) # Standard skal være 95 %-KI
-  expect_identical(aggreger_ki_prop(d_test, alfa = .05), d_svar_05)
-  expect_identical(aggreger_ki_prop(d_test, alfa = .10), d_svar_10)
+  expect_identical(aggreger_ki_prop(d_test), d_svar_95) # Standard skal være 95 %-KI
+  expect_identical(aggreger_ki_prop(d_test, konf_niva = 0.95), d_svar_95)
+  expect_identical(aggreger_ki_prop(d_test, konf_niva = 0.90), d_svar_90)
 })
 
 test_that("Funksjonen gjev alltid ut ugrupperte data", {

--- a/tests/testthat/test-aggreger_ki_rate.R
+++ b/tests/testthat/test-aggreger_ki_rate.R
@@ -153,19 +153,19 @@ test_that("Feilmelding hvis minst en ki_eksponering er mindre enn eller lik 0", 
   expect_error(aggreger_ki_rate(d_eksponering_lik_0), feilmelding)
 })
 
-test_that("Feilmelding hvis alfa ikke er et tall mellom 0 og 1", {
+test_that("Feilmelding hvis konf_niva ikke er et tall mellom 0 og 1", {
   d_var_ok = tibble(
     ki_antall = c(5, 2, 7),
     ki_eksponering = c(100, 95, 101),
     ki_aktuell = c(TRUE, TRUE, FALSE)
   )
 
-  feilmelding_alfa = "«alfa» må være et tall mellom 0 og 1"
+  feilmelding_konf_niva = "«konf_niva» må være et tall mellom 0 og 1"
 
-  expect_error(aggreger_ki_rate(d_var_ok, alfa = 1.2), feilmelding_alfa)
-  expect_error(aggreger_ki_rate(d_var_ok, alfa = 0), feilmelding_alfa)
-  expect_error(aggreger_ki_rate(d_var_ok, alfa = 1), feilmelding_alfa)
-  expect_error(aggreger_ki_rate(d_var_ok, alfa = "0.05"), feilmelding_alfa)
+  expect_error(aggreger_ki_rate(d_var_ok, konf_niva = 1.2), feilmelding_konf_niva)
+  expect_error(aggreger_ki_rate(d_var_ok, konf_niva = 0), feilmelding_konf_niva)
+  expect_error(aggreger_ki_rate(d_var_ok, konf_niva = 1), feilmelding_konf_niva)
+  expect_error(aggreger_ki_rate(d_var_ok, konf_niva = "0.95"), feilmelding_konf_niva)
 })
 
 test_that("Feilmelding hvis multiplikator ikke er et positivt heltall", {
@@ -195,23 +195,23 @@ test_that("Feilmelding hvis multiplikator ikke er et positivt heltall", {
   )
 })
 
-test_that("Feilmelding hvis alfa eller multiplikator ikke har lengde 1", {
+test_that("Feilmelding hvis konf_niva eller multiplikator ikke har lengde 1", {
   d_var_ok = tibble(
     ki_antall = c(5, 2, 7),
     ki_eksponering = c(100, 95, 101),
     ki_aktuell = c(TRUE, TRUE, FALSE)
   )
 
-  feilmelding_alfa = "«alfa» må ha lengde 1"
+  feilmelding_konf_niva = "«konf_niva» må ha lengde 1"
   feilmelding_multiplikator = "«multiplikator» må ha lengde 1"
 
   expect_error(
-    aggreger_ki_rate(d_var_ok, alfa = c()),
-    feilmelding_alfa
+    aggreger_ki_rate(d_var_ok, konf_niva = c()),
+    feilmelding_konf_niva
   )
   expect_error(
-    aggreger_ki_rate(d_var_ok, alfa = c(0.05, 0.1)),
-    feilmelding_alfa
+    aggreger_ki_rate(d_var_ok, konf_niva = c(0.95, 0.9)),
+    feilmelding_konf_niva
   )
   expect_error(
     aggreger_ki_rate(d_var_ok, multiplikator = c()),
@@ -426,12 +426,12 @@ test_that("Funksjonen støtter angivelse av konfidensinvå", {
     ki_eksponering = c(100, 95, 101),
     ki_aktuell = c(TRUE, TRUE, FALSE)
   )
-  svar_antall_lik_0_05 = tibble(
+  svar_antall_lik_0_95 = tibble(
     est = 0,
     konfint_nedre = 0,
     konfint_ovre = 0.015362729607969183993
   )
-  svar_antall_lik_0_10 = tibble(
+  svar_antall_lik_0_90 = tibble(
     est = 0,
     konfint_nedre = 0,
     konfint_ovre = 0.011808128682020746503
@@ -442,12 +442,12 @@ test_that("Funksjonen støtter angivelse av konfidensinvå", {
     ki_eksponering = c(100, 95, 101),
     ki_aktuell = c(TRUE, TRUE, FALSE)
   )
-  svar_antall_ulik_0_05 = tibble(
+  svar_antall_ulik_0_95 = tibble(
     est = 7 / 195,
     konfint_nedre = 0.015422856627814649638,
     konfint_ovre = 0.069418816705480224094
   )
-  svar_antall_ulik_0_10 = tibble(
+  svar_antall_ulik_0_90 = tibble(
     est = 7 / 195,
     konfint_nedre = 0.017943117460240590177,
     konfint_ovre = 0.063051223283699317501

--- a/tests/testthat/test-aggreger_ki_rate.R
+++ b/tests/testthat/test-aggreger_ki_rate.R
@@ -532,3 +532,15 @@ test_that("Funksjonen gjev ut tibble når inndata er tibble, og data.frame når 
   expect_identical(aggreger_ki_rate(d_test_tibble), svar_test_tibble)
   expect_identical(aggreger_ki_rate(d_test_df), svar_test_df)
 })
+
+
+test_that("Bruk av alfa gjev same svar som tilsvarande konf_niva", {
+  d = tibble(
+    ki_antall = c(5, 2, 7),
+    ki_eksponering = c(100, 95, 101),
+    ki_aktuell = c(TRUE, TRUE, TRUE)
+  )
+  expect_identical(suppressWarnings(aggreger_ki_rate(d, alfa = 0.2)),
+    expected = aggreger_ki_rate(d, konf_niva = 0.8)
+  )
+})

--- a/tests/testthat/test-aggreger_ki_rate.R
+++ b/tests/testthat/test-aggreger_ki_rate.R
@@ -285,8 +285,8 @@ test_that("Funksjonen tillater tilfeller hvor antall observasjoner er 0", {
     konfint_ovre = c(NA_real_, 0.015362729607969183993)
   )
 
-  expect_identical(aggreger_ki_rate(d_ugruppert), svar_ugruppert)
-  expect_identical(aggreger_ki_rate(d_gruppert), svar_gruppert)
+  expect_equal(aggreger_ki_rate(d_ugruppert), svar_ugruppert, tolerance = 1e-15)
+  expect_equal(aggreger_ki_rate(d_gruppert), svar_gruppert, tolerance = 1e-15)
 })
 
 
@@ -317,7 +317,10 @@ test_that("Funksjonen returnerer «NA» for de grupperte verdiene som ikke har n
     )
   )
 
-  expect_identical(aggreger_ki_rate(d_gruppert_med_na), svar_gruppert_med_na)
+  expect_equal(aggreger_ki_rate(d_gruppert_med_na),
+    expected = svar_gruppert_med_na,
+    tolerance = 1e-15
+  )
 })
 
 test_that(paste0(
@@ -345,13 +348,12 @@ test_that(paste0(
 
   feilmelding_ekstra_levels = "Det finnes grupper uten observasjoner i grupperingsvariabel"
 
-  expect_warning(
-    aggreger_ki_rate(d_gruppert_ekstra_levels),
-    feilmelding_ekstra_levels
+  expect_warning(aggreger_ki_rate(d_gruppert_ekstra_levels),
+    regexp = feilmelding_ekstra_levels
   )
-  expect_equal(
-    suppressWarnings(aggreger_ki_rate(d_gruppert_ekstra_levels)),
-    svar_gruppert_ekstra_levels
+  expect_equal(suppressWarnings(aggreger_ki_rate(d_gruppert_ekstra_levels)),
+    expected = svar_gruppert_ekstra_levels,
+    tolerance = 1e-15
   )
 })
 
@@ -453,29 +455,29 @@ test_that("Funksjonen støtter angivelse av konfidensinvå", {
     konfint_ovre = 0.063051223283699317501
   )
 
-  expect_identical(
-    aggreger_ki_rate(d_antall_lik_0),
-    svar_antall_lik_0_05
+  expect_equal(aggreger_ki_rate(d_antall_lik_0),
+    expected = svar_antall_lik_0_95,
+    tolerance = 1e-15
   ) # Standard skal være 95 %-KI
-  expect_identical(
-    aggreger_ki_rate(d_antall_lik_0, alfa = .05),
-    svar_antall_lik_0_05
+  expect_equal(aggreger_ki_rate(d_antall_lik_0, konf_niva = 0.95),
+    expected = svar_antall_lik_0_95,
+    tolerance = 1e-15
   )
-  expect_identical(
-    aggreger_ki_rate(d_antall_lik_0, alfa = .10),
-    svar_antall_lik_0_10
+  expect_equal(aggreger_ki_rate(d_antall_lik_0, konf_niva = 0.9),
+    expected = svar_antall_lik_0_90,
+    tolerance = 1e-15
   )
-  expect_identical(
-    aggreger_ki_rate(d_antall_ulik_0),
-    svar_antall_ulik_0_05
+  expect_equal(aggreger_ki_rate(d_antall_ulik_0),
+    expected = svar_antall_ulik_0_95,
+    tolerance = 1e-15
   ) # Standard skal være 95 %-KI
-  expect_identical(
-    aggreger_ki_rate(d_antall_ulik_0, alfa = .05),
-    svar_antall_ulik_0_05
+  expect_equal(aggreger_ki_rate(d_antall_ulik_0, konf_niva = 0.95),
+    expected = svar_antall_ulik_0_95,
+    tolerance = 1e-15
   )
-  expect_identical(
-    aggreger_ki_rate(d_antall_ulik_0, alfa = .10),
-    svar_antall_ulik_0_10
+  expect_equal(aggreger_ki_rate(d_antall_ulik_0, konf_niva = 0.9),
+    expected = svar_antall_ulik_0_90,
+    tolerance = 1e-15
   )
 })
 

--- a/tests/testthat/test-aggreger_ki_snitt.R
+++ b/tests/testthat/test-aggreger_ki_snitt.R
@@ -44,16 +44,16 @@ test_that("Feilmelding hvis «ki_x» er missing når «ki_aktuell» er TRUE", {
   expect_error(aggreger_ki_snitt(d_x_na), feilmelding_x_na)
 })
 
-test_that("Feilmelding hvis «alfa» ikke er et tall mellom 0 og 1", {
+test_that("Feilmelding hvis «konf_niva» ikke er et tall mellom 0 og 1", {
   d_test = tibble(
     ki_x = c(15, 12, 12),
     ki_aktuell = c(TRUE, TRUE, TRUE)
   )
-  feilmelding_alfa = "«alfa» må være et tall mellom 0 og 1"
-  expect_error(aggreger_ki_snitt(d_test, alfa = 0), feilmelding_alfa)
-  expect_error(aggreger_ki_snitt(d_test, alfa = 1), feilmelding_alfa)
-  expect_error(aggreger_ki_snitt(d_test, alfa = 1.2), feilmelding_alfa)
-  expect_error(aggreger_ki_snitt(d_test, alfa = "0.1"), feilmelding_alfa)
+  feilmelding_konf_niva = "«konf_niva» må være et tall mellom 0 og 1"
+  expect_error(aggreger_ki_snitt(d_test, konf_niva = 0), feilmelding_konf_niva)
+  expect_error(aggreger_ki_snitt(d_test, konf_niva = 1), feilmelding_konf_niva)
+  expect_error(aggreger_ki_snitt(d_test, konf_niva = 1.2), feilmelding_konf_niva)
+  expect_error(aggreger_ki_snitt(d_test, konf_niva = "0.9"), feilmelding_konf_niva)
 })
 
 test_that("Forventet utdata når inndata er gruppert og ugruppert", {
@@ -77,7 +77,7 @@ test_that("Forventet utdata når inndata er gruppert og ugruppert", {
   expect_equal(aggreger_ki_snitt(d_ugruppert), d_ugruppert_ut)
 })
 
-test_that("Forventet utdata når alfa endres fra standard", {
+test_that("Forventet utdata når konf_niva endres fra standard", {
   d_test = tibble(
     sykehus = factor(c("B", "B", "B", "A", "A", "A", "A")),
     ki_x = c(1, 2, 3, 4, 5, 6, 8), ki_aktuell = rep(TRUE, 7)
@@ -87,7 +87,7 @@ test_that("Forventet utdata når alfa endres fra standard", {
     konfint_ovre = 5.91310608095156365, n_aktuell = 7L
   )
 
-  expect_equal(aggreger_ki_snitt(d_test, alfa = 0.1), d_test_ut)
+  expect_equal(aggreger_ki_snitt(d_test, konf_niva = 0.9), d_test_ut)
 })
 
 test_that("Gir alltid ut ugrupperte data", {

--- a/tests/testthat/test-aggreger_ki_snitt.R
+++ b/tests/testthat/test-aggreger_ki_snitt.R
@@ -147,3 +147,13 @@ test_that("Gir NA-konfidensgrenser hvis standardavvik er 0 i en gruppe", {
 
   expect_equal(aggreger_ki_snitt(d_sd_lik_null), d_sd_lik_null_ut)
 })
+
+test_that("Bruk av alfa gjev same svar som tilsvarande konf_niva", {
+  d = tibble(
+    sykehus = factor(c("B", "B", "B", "A", "A", "A", "A")),
+    ki_x = c(1, 2, 3, 4, 5, 6, 8), ki_aktuell = rep(TRUE, 7)
+  )
+  expect_identical(suppressWarnings(aggreger_ki_snitt(d, alfa = 0.2)),
+    expected = aggreger_ki_snitt(d, konf_niva = 0.8)
+  )
+})

--- a/tests/testthat/test-regn_konfint_bin.R
+++ b/tests/testthat/test-regn_konfint_bin.R
@@ -4,3 +4,9 @@ test_that("Funksjonen gir konfindensintervall med øvre grense 1 og nedre nedre 
   expect_false(any(regn_konfint_bin(1:1000, 1:1000)$upper > 1))
   expect_false(any(regn_konfint_bin(0, 1:1000)$lower < 0))
 })
+
+test_that("Bruk av alfa gjev same svar som tilsvarande konf_niva", {
+  expect_identical(suppressWarnings(regn_konfint_bin(5, 10, alfa = 0.2)),
+    expected = regn_konfint_bin(5, 10, konf_niva = 0.8)
+  )
+})


### PR DESCRIPTION
Fylgjer endringa allereie gjort i `regn_konfint_univar()` (jf. https://github.com/Rapporteket/rapwhale/commit/b4ff3594779c37be3ca1c0ba55ccfca2682b705c).

Har gjort det gamle argumentet `alfa` utdatert ved hjelp av `lifecycle`, slik at ein får åtvaring om ein brukar argumentet.