### PR TITLE
Gjort `aggreger_ki_prop()` og `aggreger_ki_snitt()` stabile

### DIFF
--- a/R/aggreger_ki_prop.R
+++ b/R/aggreger_ki_prop.R
@@ -1,7 +1,7 @@
 #' Regn ut kvalitetsindikator for andeler
 #'
 #' @description
-#' `r lifecycle::badge("maturing")`
+#' `r lifecycle::badge("stable")`
 #'
 #' Regner ut kvalitetsindikator for andeler (teller delt på nevner)
 #' basert på et standard datasett for binomiske data / andelsdata.

--- a/R/aggreger_ki_snitt.R
+++ b/R/aggreger_ki_snitt.R
@@ -1,7 +1,7 @@
 #' Regn ut kvalitetsindikator for gjennomsnitt
 #'
 #' @description
-#' `r lifecycle::badge("maturing")`
+#' `r lifecycle::badge("stable")`
 #'
 #' Regner ut kvalitetsindikator med gjennomsnitt av kontinuerlige data,
 #' basert på et standard datasett for dette.


### PR DESCRIPTION
Funksjonane er no kvalitetssikra av to personar, har 100 % dekningsgrad på testane og oppfyller krava til å verta merkte som stabile.