### PR TITLE
Fjerna overflødig geom_point()

### DIFF
--- a/R/figur-funksjoner.R
+++ b/R/figur-funksjoner.R
@@ -213,9 +213,6 @@ lag_fig_shewhart = function(d, y, x, figtype, nevner = NULL, tittel = NULL,
   if (figtype == "p") { # hvis det er p-chart ønsker vi norske prosenter fra funksjon i dette r-skriptet
     plot = plot + scale_y_continuous(labels = akse_prosent_format(0))
   }
-  if (lubridate::is.Date(d[[qic_x]])) { # hvis det er en tidsvisning trenger vi en dot for punktene i linjediagrammet
-    plot = plot + ggplot2::geom_point()
-  }
   plot
 }
 


### PR DESCRIPTION
Dette overskreiv signalpunkt med vanlig farge når det var dato på x-aksen.

Det har kanskje fungert som tenkt med ein gamal versjon av qicharts2-pakken?