### PR TITLE
Ta i bruk CODEOWNERS-fil

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @haugedal

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "haugedal"


### PR DESCRIPTION
Reviewers-innstillinga for dependabot er fjerna:
[Dependabot reviewers configuration option being replaced by code owners - GitHub Changelog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

Bruk heller CODEOWNERS:
[About code owners - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)